### PR TITLE
Get archived Tasks and Events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,16 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+
+# PyBuilder
+target/
 salesforce_bulk.egg-info*
 */salesforce_bulk.egg-info/*
 build/*
 dist/*
+
+# Local Dev
+.idea
+

--- a/salesforce_bulk/salesforce_bulk.py
+++ b/salesforce_bulk/salesforce_bulk.py
@@ -51,7 +51,7 @@ class BulkBatchFailed(BulkApiError):
 class SalesforceBulk(object):
 
     def __init__(self, sessionId=None, host=None, username=None, password=None,
-                 exception_class=BulkApiError, version='33.0'):
+                 exception_class=BulkApiError, version='39.0'):
         if not sessionId and not username:
             raise RuntimeError(
                 "Must supply either sessionId/instance_url or username/password")

--- a/salesforce_bulk/salesforce_bulk.py
+++ b/salesforce_bulk/salesforce_bulk.py
@@ -119,7 +119,7 @@ class SalesforceBulk(object):
     def create_delete_job(self, object_name, **kwargs):
         return self.create_job(object_name, "delete", **kwargs)
 
-    def create_job(self, object_name=None, operation=None, contentType='CSV',
+    def create_job(self, object_name=None, operation=None, contentType='XML',
                    concurrency=None, extra_headers=None):
         assert(object_name is not None)
         assert(operation is not None)

--- a/salesforce_bulk/salesforce_bulk.py
+++ b/salesforce_bulk/salesforce_bulk.py
@@ -107,6 +107,9 @@ class SalesforceBulk(object):
     def create_query_job(self, object_name, **kwargs):
         return self.create_job(object_name, "query", **kwargs)
 
+    def create_query_all_job(self, object_name, **kwargs):
+        return self.create_job(object_name, "queryAll", **kwargs)
+
     def create_insert_job(self, object_name, **kwargs):
         return self.create_job(object_name, "insert", **kwargs)
 


### PR DESCRIPTION
## Description of the change

This PR is part of [salesforce-extractor#14](https://github.com/etleap/salesforce-extractor/pull/14).

Salesforce's Bulk API now allows the use of the `queryAll` operation to retrieve archived Tasks and Events. This PR adds a convenience method to create a `queryAll` job.

Support for the operation starts at version `39.0`, so the extractor has been updated to use this version throughout the `salesforce-extractor`, `salesforce-bulk`, and `simple-salesforce` repos, as many different default version numbers were being used in different places.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related story in Pivotal

[Get archived Salesforce tasks](https://www.pivotaltracker.com/story/show/169416940)

## Checklists

### Development

- [x] The code changed/added as part of this pull request has been covered with tests.
- [x] All tests related to the changed code pass in development.

### Code review 

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [x] Reviews have been requested.
- [ ] Changes have been reviewed and accepted by at least one other engineer.
- [x] The Pivotal story has a link to this pull request.
